### PR TITLE
add docker file and help text

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,14 @@ RUN npm install
 
 RUN npm run app:release
 
-RUN  npm run styles:release
+RUN npm run styles:release
 
 RUN rm -rf $HOME/.convex
 RUN mkdir -p $HOME/.convex
-RUN echo "{:key-store-passphrase \"secret\" \
- :key-passphrase \"secret\"}" > $HOME/.convex/secrets.edn
+RUN echo "{:key-store-passphrase \"password\" \
+ :key-passphrase \"password\"}" > $HOME/.convex/secrets.edn
+ADD config.edn $HOME/.convex/config.edn
+RUN rm $HOME/config.edn
+RUN ln -s $HOME/.convex/config.edn $HOME/config.edn
 
-CMD clojure -J-Duser.home=$HOME -M:repl:dev:logback-dev -e "(go)"
+CMD clojure -J-Duser.home=$HOME -M:main:repl:logback-prod -e "(go)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Docker for convex web
+
+FROM node:latest
+
+ENV HOME=/home/convex-web
+
+ENV CLOJURE_VER=1.10.3.933
+
+RUN apt-get update \
+  && apt-get -q -y install openjdk-11-jdk curl \
+  && npm install -g shadow-cljs \
+  && curl -s https://download.clojure.org/install/linux-install-$CLOJURE_VER.sh | bash
+
+WORKDIR $HOME
+
+ADD . $HOME
+
+RUN npm install
+
+RUN npm run app:release
+
+RUN  npm run styles:release
+
+RUN rm -rf $HOME/.convex
+RUN mkdir -p $HOME/.convex
+RUN echo "{:key-store-passphrase \"secret\" \
+ :key-passphrase \"secret\"}" > $HOME/.convex/secrets.edn
+
+CMD clojure -J-Duser.home=$HOME -M:repl:dev:logback-dev -e "(go)"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ Start server on port 8080:
 (go)
 ```
 
+## Docker Testing
+
+To run convex-web as a local docker container, you will need to do the following.
+
+Build the docker image
+```
+docker build -t convex-web .
+```
+
+Run the docker image
+```
+docker run --publish 8080:8080 convex-web
+```
+
 ## Production
 
 ### App


### PR DESCRIPTION
This adds docker setup file and help text, so that convex-web can be run locally using Docker.
