### PR TITLE
Correct broken link

### DIFF
--- a/src/main/resources/markdown/dev_doc/cvm/basic-syntax.md
+++ b/src/main/resources/markdown/dev_doc/cvm/basic-syntax.md
@@ -18,7 +18,7 @@ Once again, simple maths dictates that one can be fully explicit by using parens
 Now, without knowing anything about the order of operations but knowing about parens, we know for sure that `(2 * 3)` is computed first, and then `(4 + 6)`. No other rule
 must be remembered but this one: inner parens are executed before outer parens.
 
-Instead of talking about mathematical operators, the primary unit of computation in Convex Lisp is the [function](/functions). Values provided to functions are called
+Instead of talking about mathematical operators, the primary unit of computation in Convex Lisp is the [function](/cvm/building-blocks/functions). Values provided to functions are called
 **parameters**. Later sections will describe how you can write your own functions and do anything you can imagine. Functions are always specified first in so-called
 **prefix notation** and then parameters are provided. Hence, here is the above example written in Convex Lisp:
 

--- a/src/main/resources/markdown/dev_doc/cvm/building-blocks/definitions.md
+++ b/src/main/resources/markdown/dev_doc/cvm/building-blocks/definitions.md
@@ -1,5 +1,5 @@
 First and foremost, Convex can be understood as a decentralized database capable of storing **cells**. A cell can be any type of values encountered in these guides,
-from [data types](/cvm/data-types) to [functions](/cvm/function). This section reviews how arbitrary cells can be stored across transactions, as long as required.
+from [data types](/cvm/data-types) to [functions](cvm/building-blocks/functions). This section reviews how arbitrary cells can be stored across transactions, as long as required.
 
 Each account has an **environment**. Conceptually, an environment can be understood as a [map](/cvm/data-types/map) where keys are [symbols](/cvm/data-types/symbol)
 and values can be anything. A symbol pointing to an arbitrary value is called a **definition**.


### PR DESCRIPTION
In building-blocks/definions, the page is not found, when clicking on **functions**. This is corrected in this commit.