### PR TITLE
Build uberjar on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,8 @@ jobs:
       - run:
           name: Create uberjar
           command: |
-            script/build/uberjar
-            RELEASE=/tmp/release
-            script/ci/release                        
+            script/build/uberjar            
+            RELEASE=/tmp/release script/ci/release                        
       - store_artifacts:
           path: /tmp/release
           destination: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             DIR=/tmp/release script/ci/release
       - store_artifacts:
           path: /tmp/release
-          destination: release.jar
+          destination: release
       - save_cache:
           paths:
             - ~/.m2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,55 @@
+# Clojure CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-clojure/ for more details
+#
+version: 2.1
+
+jobs:
+  deploy:
+    docker:
+      - image: cimg/clojure:1.11.1
+    working_directory: ~/repo
+    # resource_class: large
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "deps.edn" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      # - run:
+      #     name: Run JVM tests
+      #     command: |
+      #       script/test
+      #       script/run_lib_tests
+      - run:
+          name: Create uberjar
+          command: |
+            script/build/uberjar
+            RELEASE=/tmp/release
+            script/ci/release                        
+      - store_artifacts:
+          path: /tmp/release
+          destination: release
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "deps.edn" }}
+
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      # - short-if-irrelevant
+      # - jvm:
+      #     requires:
+      #        - short-if-irrelevant
+      - deploy:
+          # filters:
+          #   branches:
+          #     only: master
+          # requires:
+          #   - jvm
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,12 @@ jobs:
       - run:
           name: Create uberjar
           command: |
-            script/build/uberjar            
-            RELEASE=/tmp/release script/ci/release                        
+            script/build/uberjar
+            mkdir -p /tmp/release
+            DIR=/tmp/release script/ci/release
       - store_artifacts:
           path: /tmp/release
-          destination: release
+          destination: release.jar
       - save_cache:
           paths:
             - ~/.m2

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ convex-db
 convex-web.sublime-workspace
 .clj-kondo
 *.pfx
+build/**

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,52 @@
+(ns build
+  (:require
+    [clojure.tools.build.api :as b]))
+    
+;; More info see https://clojure.org/guides/tools_build
+
+;; Project settings
+
+(def lib           'convex/convex-web)
+(def main-class    'convex-web.core)
+(def src-dirs      ["src/main/clojure"])
+(def resource-dirs ["src/main/resources"])
+
+;; General settings
+
+(def version (format "0.1.%s" (b/git-count-revs nil)))
+ 
+(def build-path "build")
+(def class-dir (str build-path "/classes"))
+
+(def basis (b/create-basis {:project "deps.edn"}))
+(def dirs-to-copy (concat src-dirs resource-dirs))
+
+
+(defn clean [_]
+  (b/delete {:path build-path}))
+
+
+(def uber-file (format "%s-%s-standalone.jar" (name lib) version))
+(def uber-full-path (str build-path "/" uber-file))
+(def build-uberjar-name-file (str build-path "/" "UBERJAR_FILENAME"))
+
+(defn uberjar [{:as opts}]
+  (clean nil)
+  (b/write-pom {:class-dir class-dir
+                :lib       lib
+                :version   version
+                :basis     basis
+                :src-dirs  src-dirs})
+  (b/copy-dir {:src-dirs   dirs-to-copy
+               :target-dir class-dir})
+  ;; Compile not necesary, we can skip this
+  (b/compile-clj {:basis     basis
+                  :src-dirs  src-dirs
+                  :class-dir class-dir
+                  :java-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]})
+  (b/uber {:class-dir class-dir
+           :uber-file uber-full-path
+           :basis     basis
+           :main      main-class})
+  ;; Write filename to specific file for CI
+  (spit build-uberjar-name-file uber-file))

--- a/deps.edn
+++ b/deps.edn
@@ -147,6 +147,9 @@
   :logback-prod
   {:jvm-opts ["-Dlogback.configurationFile=logback/logback-prod.xml"]}
   
+  ;; -- Build configuration
+ :build {:deps {io.github.clojure/tools.build {:git/tag "v0.8.2" :git/sha "ba1a2bf"}}
+         :ns-default build}
   
   ;; -- Check outdated dependencies
   ;; clj -M:outdated

--- a/script/build/uberjar
+++ b/script/build/uberjar
@@ -1,3 +1,3 @@
 #!/bin/sh -x
 
-clj -T:build uberjar
+clojure -T:build uberjar

--- a/script/build/uberjar
+++ b/script/build/uberjar
@@ -1,0 +1,3 @@
+#!/bin/sh -x
+
+clj -T:build uberjar

--- a/script/ci/release
+++ b/script/ci/release
@@ -1,5 +1,6 @@
 #!/bin/sh -x
 
 UBERJAR_FILENAME=$(cat build/UBERJAR_FILENAME)
+RELEASE="$DIR/$UBERJAR_FILENAME"
 cp build/${UBERJAR_FILENAME} $RELEASE
 java -cp "$RELEASE" clojure.main -e '(println "OK")'

--- a/script/ci/release
+++ b/script/ci/release
@@ -1,0 +1,5 @@
+#!/bin/sh -x
+
+UBERJAR_FILENAME=$(cat build/UBERJAR_FILENAME)
+cp build/${UBERJAR_FILENAME} $RELEASE
+java -cp "$RELEASE" clojure.main -e '(println "OK")'

--- a/src/main/clojure/convex_web/core.clj
+++ b/src/main/clojure/convex_web/core.clj
@@ -4,7 +4,8 @@
             [clojure.tools.logging :as log])
   
   (:import 
-   (convex.core.util Shutdown)))
+   (convex.core.util Shutdown))
+  (:gen-class))
 
 (def system nil)
 


### PR DESCRIPTION
This work is a proof of concept for releasing uberjars via CI

It includes
- a build script for uberjar creation
- a configuration for CircleCI to build the uberjar and release it under artififacts

The jar can be run after downloading via one of the following commands:

```
java -jar build/convex-web-0.1.2053-standalone.jar
java -cp build/convex-web-0.1.2053-standalone.jar convex_web.core
java -cp build/convex-web-0.1.2053-standalone.jar clojure.main -m convex-web.core
```

The latter two variants can start a repl by using the property syntax
```
java -cp build/convex-web-0.1.2053-standalone.jar -Dclojure.server.repl="{:port,5555,:accept,clojure.core.server/repl}"clojure.main -m convex-web.core
```